### PR TITLE
 fix bug: not for \n to be used in unicodedata.name

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,9 @@ from flask import Flask, jsonify
 
 def is_japanese(string):
     for ch in string:
+        # \n is not used in unicodedata.name
+        if ch is '\n':
+            continue
         name = unicodedata.name(ch)
         if "CJK UNIFIED" in name \
         or "HIRAGANA" in name \


### PR DESCRIPTION
# 背景
#2 

# 🦐
![image](https://user-images.githubusercontent.com/13075237/52164406-34da1180-2734-11e9-9010-13cf5c29679a.png)
